### PR TITLE
refactor : 사용자의 숫자를 검증하는 부분에 사용하는 정규식 수정

### DIFF
--- a/src/main/java/baseball/util/InputUtil.java
+++ b/src/main/java/baseball/util/InputUtil.java
@@ -1,10 +1,10 @@
 package baseball.util;
 
+import baseball.constant.GameConstant;
 import camp.nextstep.edu.missionutils.Console;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 public class InputUtil {
 
@@ -39,7 +39,9 @@ public class InputUtil {
 
     //서로다른 3가지 숫자인지 체크
     private boolean isValidString(String input) {
-        return input.matches("^(?!.*(.).*\\1)[1-9]{3}$");
+        String regex = "^(?!.*(.).*\\1)[" + GameConstant.GAME_START_INCLUSIVE +
+                "-" + GameConstant.GAME_END_INCLUSIVE + "]{" + GameConstant.NUMBER_COUNT + "}$";
+        return input.matches(regex);
     }
 
     private boolean isValidReplayCommand(String replayCommand) {


### PR DESCRIPTION
## 🧑‍💻 작업 내용
> 작업한 내용 정리
- 사용자의 숫자를 검증하는 부분에 사용하는 정규식 수정
- 정규식에 사용하는 매직넘버를 enum 상수를 사용하는 방식으로 변경

<br>

## 🚀 이슈
> 발생 이슈 없을시 생략 가능
- 정규식 문자열의 `"]{"` 부분에서 컴파일 에러가 아닌 에러가 발생하는데 그냥 놔둬도 괜찮은가?



<br>
