### PR TITLE
fix : 컴퓨터의 번호를 생성하는 부분 오류 수정

### DIFF
--- a/src/main/java/baseball/util/NumberGenerator.java
+++ b/src/main/java/baseball/util/NumberGenerator.java
@@ -7,14 +7,13 @@ import java.util.List;
 
 public class NumberGenerator {
 
-    private final List<Integer> generatedNumber;
+    private List<Integer> generatedNumber;
 
     public NumberGenerator() {
-        this.generatedNumber = new ArrayList<>();
     }
 
     public List<Integer> generate() {
-
+        this.generatedNumber = new ArrayList<>();
         while (generatedNumber.size() < 3) {
             int number = Randoms.pickNumberInRange(
                     GameConstant.NUMBER_START_INCLUSIVE.getConstant(),


### PR DESCRIPTION
## 🧑‍💻 작업 내용
> 작업한 내용 정리
- 컴퓨터의 번호를 생성하는 메소드 수정
- `NumberGenerator` 를 생성한 후 번호를 생성하는 메소드인 `generate` 메소드를 호출할때 배열을 초기화 하는 방식으로 변경
   - `NumberGenerator` 를 여러번 호출했을때 같은 번호를 만들수 있는 현상 방지



<br>

## 🚀 이슈
> 발생 이슈 없을시 생략 가능




<br>
